### PR TITLE
Build project on a push using github worflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Laminar CI
+
+on: [push]
+
+env:
+  WRAPPER_VERBOSE: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Ant
+        run: ant -noinput -buildfile build.xml


### PR DESCRIPTION
Build project on a push to any branch.

It is implemented using the Github action feature using a variant of their stock ant build:
https://help.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-ant

Added a low timeout to cancel the build.